### PR TITLE
make compatible with invest 3.17.0 and update guidance on conda deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,9 +8,7 @@ name = "invest-demo-plugin"
 # Using setuptools_scm is not required, but we highly recommend it
 dynamic = ["version"]  
 dependencies = [
-  "pygeoprocessing", 
   "taskgraph",
-  "natcap.invest>=3.16.0"
 ]
 
 [tool.setuptools_scm]
@@ -30,10 +28,10 @@ api_version = "v1"
 # or other special characters because it will be used in an import statement.
 package_name = "invest_demo_plugin"
 
-# List of conda dependencies to install into the plugin's conda env 
-# Only include dependencies that cannot be specified in project.dependencies because 
-# they are not available thru pip. Usually this is only python itself, and any 
-# non-python dependencies like the GDAL binaries.
+# List of conda dependencies to install into the plugin's conda env. 
+# Include dependencies that can be installed from conda-forge.
+# Usually this includes python itself, any non-python dependencies
+# like the GDAL binaries, and any other packages available from conda-forge.
 #
 # Only the conda-forge channel is supported. These dependencies MUST be available on 
 # conda-forge. We have disabled the default channel due to Anaconda's licensing.
@@ -43,7 +41,9 @@ package_name = "invest_demo_plugin"
 conda_dependencies = [
   "python==3.13",  
   "gdal<3.11",  # missing libgdal.so issue happened with gdal 3.11
-  "geotiff>=1.7.3"  # earlier versions don't support space in CONDA_PREFIX
+  "geotiff>=1.7.3",  # earlier versions don't support space in CONDA_PREFIX
+  "pygeoprocessing",
+  "natcap.invest>=3.17.0"
 ]
 
 [tool.setuptools.package-data]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,13 @@ name = "invest-demo-plugin"
 # Allow setuptools_scm to derive the version dynamically from the git metadata
 # Using setuptools_scm is not required, but we highly recommend it
 dynamic = ["version"]  
+
+# All direct python dependencies should be listed here. If a package is
+# available from conda-forge, it can also be listed under the conda_dependencies.
 dependencies = [
+  "pygeoprocessing",
   "taskgraph",
+  "natcap.invest>=3.17.0"
 ]
 
 [tool.setuptools_scm]
@@ -28,10 +33,11 @@ api_version = "v1"
 # or other special characters because it will be used in an import statement.
 package_name = "invest_demo_plugin"
 
-# List of conda dependencies to install into the plugin's conda env. 
-# Include dependencies that can be installed from conda-forge.
-# Usually this includes python itself, any non-python dependencies
-# like the GDAL binaries, and any other packages available from conda-forge.
+# List of conda dependencies to install into the plugin's conda environment. 
+# Usually this includes python itself and any non-python dependencies
+# like the GDAL binaries. Packages listed here will be installed into the
+# plugin environment prior to the other dependencies, so you may wish to list
+# packages here that are difficult to install with pip.
 #
 # Only the conda-forge channel is supported. These dependencies MUST be available on 
 # conda-forge. We have disabled the default channel due to Anaconda's licensing.
@@ -42,8 +48,8 @@ conda_dependencies = [
   "python==3.13",  
   "gdal<3.11",  # missing libgdal.so issue happened with gdal 3.11
   "geotiff>=1.7.3",  # earlier versions don't support space in CONDA_PREFIX
-  "pygeoprocessing",
-  "natcap.invest>=3.17.0"
+  "pygeoprocessing",  # install from conda-forge rather than building wheel with pip
+  "natcap.invest>=3.17.0"  # install from conda-forge rather than building wheel with pip
 ]
 
 [tool.setuptools.package-data]

--- a/src/invest_demo_plugin/foo.py
+++ b/src/invest_demo_plugin/foo.py
@@ -15,6 +15,7 @@ LOGGER = logging.getLogger(__name__)
 MODEL_SPEC = spec.ModelSpec(
     model_id="demo",
     model_title=gettext("Demo Plugin"),
+    module_name=__name__,
     userguide='',
     input_field_order=[
         ['workspace_dir', 'results_suffix'],
@@ -67,7 +68,8 @@ MODEL_SPEC = spec.ModelSpec(
     ],
     outputs=[
         spec.SingleBandRasterOutput(
-            id="result.tif",
+            id="result",
+            path="result.tif",
             about="Raster multiplied by factor",
             data_type=float,
             units=None


### PR DESCRIPTION
Fixes #3 

@emlys do you agree with this guidance on what to include as the conda dependencies? Or is there a reason to prefer keeping them to a minimum? It seems like installing pre-built binaries from conda-forge is preferable when possible, to avoid potential challenges with building wheels.

Also updated to latest model spec API.